### PR TITLE
feat: add executor for android step

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ yarn collect-fbts
 yarn translate-fbts
 # 4. Generate android/res translation files by running the
 #    generate-android-localizable script with the ouput of translate-fbts
+yarn generate-android-fbt
 # 5. Run a local web server with hot reloading at localhost:8081
 yarn android
 ```

--- a/i18n/scripts/generate-android-localizables-executor.js
+++ b/i18n/scripts/generate-android-localizables-executor.js
@@ -1,0 +1,37 @@
+/**
+ * Nice wraper to use generate-android-localizables from babel node directly
+ */
+
+'use strict';
+
+const { generateAndroidLocalizableFiles } = require('./generate-android-localizables');
+const yargs = require('yargs');
+const fs = require('fs');
+
+const args = {
+  HELP: 'h',
+  TRANSLATION_OUTPUT: 'translationOutput',
+  ANDROID_RES_DIR: 'androidResDir',
+  TRANSLATIONS_FILENAME: 'translationsFilename',
+};
+
+const argv = yargs
+  .usage(
+    'Take translations output, and write individual JSON files for each locale:  raw-es_rES/localizable.json => {<hash>: translatedString}',
+  )
+  .string(args.TRANSLATION_OUTPUT)
+  .default(args.TRANSLATION_OUTPUT, './i18n/fbt/translatedFbts.json')
+  .describe(args.TRANSLATION_OUTPUT, `path to the translatedFbts`)
+  .string(args.ANDROID_RES_DIR)
+  .default(args.ANDROID_RES_DIR, 'android/app/src/main/res')
+  .describe(args.ANDROID_RES_DIR, `path to the res folder of your android application`)
+  .string(args.TRANSLATIONS_FILENAME)
+  .default(args.TRANSLATIONS_FILENAME, 'localizable.json')
+  .describe(args.TRANSLATIONS_FILENAME, `name that json translation files should take`).argv;
+
+if (argv[args.HELP]) {
+  yargs.showHelp();
+  process.exit(0);
+}
+
+generateAndroidLocalizableFiles(JSON.parse(fs.readFileSync(argv[args.TRANSLATION_OUTPUT])), argv[args.ANDROID_RES_DIR], argv[args.TRANSLATIONS_FILENAME]);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "manifest": "babel-node ./node_modules/babel-plugin-fbt/bin/manifest --src src/ --enum-manifest i18n/fbt/.enum_manifest.json --src-manifest i18n/fbt/.src_manifest.json",
     "collect-fbts": "babel-node ./node_modules/babel-plugin-fbt/bin/collectFBT --hash-module 'fb-tiger-hash/hashPhrases' --react-native-mode --manifest < i18n/fbt/.src_manifest.json > i18n/fbt/.source_strings.json",
     "translate-fbts": "babel-node ./node_modules/babel-plugin-fbt/bin/translate.js --jenkins --source-strings i18n/fbt/.source_strings.json --translations i18n/fbt/translationScriptInput/*.json > i18n/fbt/translatedFbts.json",
+    "generate-android-fbt": "babel-node i18n/scripts/executor.js", 
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "manifest": "babel-node ./node_modules/babel-plugin-fbt/bin/manifest --src src/ --enum-manifest i18n/fbt/.enum_manifest.json --src-manifest i18n/fbt/.src_manifest.json",
     "collect-fbts": "babel-node ./node_modules/babel-plugin-fbt/bin/collectFBT --hash-module 'fb-tiger-hash/hashPhrases' --react-native-mode --manifest < i18n/fbt/.src_manifest.json > i18n/fbt/.source_strings.json",
     "translate-fbts": "babel-node ./node_modules/babel-plugin-fbt/bin/translate.js --jenkins --source-strings i18n/fbt/.source_strings.json --translations i18n/fbt/translationScriptInput/*.json > i18n/fbt/translatedFbts.json",
-    "generate-android-fbt": "babel-node i18n/scripts/executor.js", 
+    "generate-android-fbt": "babel-node i18n/scripts/generate-android-localizables-executor.js", 
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",


### PR DESCRIPTION
I had to spend time figuring out `step 4.` from the `README.md` hopefully, this will help someone in the future. 

If this get merged, I will open a PR pointing to master to updated the React-Native documentation. 