### PR TITLE
added __self to fbt ignored props

### DIFF
--- a/packages/babel-plugin-fbt/FbtConstants.js
+++ b/packages/babel-plugin-fbt/FbtConstants.js
@@ -91,6 +91,11 @@ const FbtRequiredAttributes = {
   desc: true,
 };
 
+const FbtIgnoredAttributes = {
+  __self: true,
+  ...FbtRequiredAttributes,
+};
+
 const PronounRequiredAttributes = {
   type: true,
   gender: true,
@@ -100,6 +105,11 @@ const PLURAL_PARAM_TOKEN = 'number';
 
 const RequiredParamOptions = {
   name: true,
+};
+
+const IgnoredParamOptions = {
+  __self: true,
+  ...RequiredParamOptions,
 };
 
 const ValidParamOptions = {
@@ -131,6 +141,7 @@ module.exports = {
   FbtBooleanOptions,
   FbtCallMustHaveAtLeastOneOfTheseAttributes,
   FbtRequiredAttributes,
+  FbtIgnoredAttributes,
   FbtType,
   JSModuleName,
   ModuleNameRegExp,
@@ -139,6 +150,7 @@ module.exports = {
   PluralRequiredAttributes,
   PronounRequiredAttributes,
   RequiredParamOptions,
+  IgnoredParamOptions,
   ValidFbtOptions,
   ValidParamOptions,
   ValidPluralOptions,

--- a/packages/babel-plugin-fbt/__tests__/fbtJsx-test.js
+++ b/packages/babel-plugin-fbt/__tests__/fbtJsx-test.js
@@ -583,6 +583,25 @@ const testData = {
     ),
   },
 
+  'should not throw on attributes that are explictly ignored': {
+    input: withFbtRequireStatement(
+      `<fbt desc="some-desc" __self={this}>
+        <fbt:param name="foo" __self={this}>
+          !{foo}!
+        </fbt:param>
+      </fbt>`
+    ),
+
+    output: withFbtRequireStatement(
+      `fbt._(
+        ${payload({
+          type: "text",
+          jsfbt: "{foo}",
+          desc: "some-desc",
+        })}, [fbt._param("foo", foo)]);`
+    ),
+  },
+
   'should maintain order of params and enums': {
     input: withFbtRequireStatement(
       `<fbt desc="some-desc">

--- a/packages/babel-plugin-fbt/babel-processors/JSXFbtProcessor.js
+++ b/packages/babel-plugin-fbt/babel-processors/JSXFbtProcessor.js
@@ -31,7 +31,7 @@ const FbtAutoWrap = require('../FbtAutoWrap');
 const FbtCommon = require('../FbtCommon');
 const {
   FbtCallMustHaveAtLeastOneOfTheseAttributes,
-  FbtRequiredAttributes,
+  FbtIgnoredAttributes,
   ValidFbtOptions,
 } = require('../FbtConstants');
 const FbtNodeChecker = require('../FbtNodeChecker');
@@ -134,7 +134,7 @@ class JSXFbtProcessor {
         this.t,
         attrs,
         ValidFbtOptions,
-        FbtRequiredAttributes,
+        FbtIgnoredAttributes,
       )
       : null;
   }

--- a/packages/babel-plugin-fbt/getNamespacedArgs.js
+++ b/packages/babel-plugin-fbt/getNamespacedArgs.js
@@ -16,7 +16,7 @@ const {
   PluralOptions,
   PluralRequiredAttributes,
   PronounRequiredAttributes,
-  RequiredParamOptions,
+  IgnoredParamOptions,
   ValidParamOptions,
   ValidPronounOptions,
   ValidPronounUsages,
@@ -51,7 +51,7 @@ const getNamespacedArgs = function(moduleName, t) {
         t,
         attributes,
         ValidParamOptions,
-        RequiredParamOptions,
+        IgnoredParamOptions,
       );
 
       let paramChildren = filterEmptyNodes(node.children).filter(function(


### PR DESCRIPTION
## Summary

Recently, a bugfix went out for `babel-plugin-transform-react-jsx-self` that moves adding the `__self` JSX attribute before the arrow function transform. This has the side effect of adding the `__self` attribute before the fbt transform as well. This PR marks `__self` as a passed through but purposefully ignored attribute so that this change does not cause fbt to throw because of an unknown attribute

## Test plan
I wrote a test to verify that the attribute is ignored. I also manually changed the code in the WWW repo and verified running the `self` transform in conjunction with this transform no longer throws an error.