### PR TITLE
Add Babel presets as a cli option for fbt-collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ We haven't had the best track record of code/feature changes before this date, b
   <summary>
    Unreleased changes that have landed in master. Click to see more.
   </summary>
+  - [feat] Add babel presets as a cli option for fbt-collect cli
   - [fix] Render optional catch binding syntax to ES5 to fix [IE11 bug](https://github.com/facebook/fbt/pull/139)
   - [feat] Convert `fbt.isFbtInstance()` to a predicate function for Flow
   - [fix] Avoid generating unnecessary empty strings in fbt result contents

--- a/packages/babel-plugin-fbt/bin/FbtCollector.js
+++ b/packages/babel-plugin-fbt/bin/FbtCollector.js
@@ -17,12 +17,13 @@ const {SyntaxPlugins} = require('fb-babel-plugin-utils');
 const fs = require('graceful-fs');
 
 /*::
-import type {BabelPluginList} from '@babel/core';
+import type {BabelPluginList, BabelPresetList} from '@babel/core';
 import type {Phrase} from '../index';
 type CollectorConfig = {|
   auxiliaryTexts: boolean,
   fbtCommonPath?: string,
   plugins?: BabelPluginList,
+  presets?: BabelPresetList,
   reactNativeMode?: boolean,
 |};
 export type ChildParentMappings = {[prop: number]: number}
@@ -51,12 +52,14 @@ function transform(
   code /*: string*/,
   options /*: TransformOptions*/,
   plugins /*: BabelPluginList */,
+  presets  /*: BabelPresetList */
 )/*: void*/ {
   const opts = {
     ast: false,
     code: false,
     filename: options.filename,
     plugins: SyntaxPlugins.list.concat(plugins, [[fbt, options]]),
+    presets,
     sourceType: 'unambiguous',
   };
   babel.transformSync(code, opts);
@@ -97,7 +100,7 @@ class FbtCollector {
       return;
     }
 
-    transform(source, options, this._config.plugins || []);
+    transform(source, options, this._config.plugins || [], this._config.presets || []);
 
     let newPhrases = fbt.getExtractedStrings();
     if (this._config.reactNativeMode) {

--- a/packages/babel-plugin-fbt/bin/collectFBT.js
+++ b/packages/babel-plugin-fbt/bin/collectFBT.js
@@ -28,6 +28,7 @@ const args = {
   OPTIONS: 'options',
   PACKAGER: 'packager',
   PLUGINS: 'plugins',
+  PRESETS: 'presets',
   PRETTY: 'pretty',
   REACT_NATIVE_MODE: 'react-native-mode',
   TERSE: 'terse',
@@ -104,6 +105,12 @@ const argv = yargs
     args.PLUGINS,
     'List of auxiliary Babel plugins to enable for parsing source.\n' +
       'E.g. --plugins @babel/plugin-syntax-dynamic-import @babel/plugin-syntax-numeric-separator',
+  ).array(args.PRESETS)
+  .default(args.PRESETS, [])
+  .describe(
+    args.PRESETS,
+    'List of auxiliary Babel presets to enable for parsing source.\n' +
+      'E.g. --presets @babel/preset-typescript',
   )
   .string(args.OPTIONS)
   .describe(
@@ -141,6 +148,7 @@ const fbtCollector = new FbtCollector(
   {
     auxiliaryTexts: argv[args.AUXILIARY_TEXTS],
     plugins: argv[args.PLUGINS].map(require),
+    presets: argv[args.PRESETS].map(require),
     reactNativeMode: argv[args.REACT_NATIVE_MODE],
     fbtCommonPath: argv[args.COMMON_STRINGS],
   },


### PR DESCRIPTION
## Summary

When running fbt-collect on a Typescript file, it errors out with syntax errors due to Babel not recognizing Typescript-specific syntax. In order to have have Babel understand this syntax, you need to run Babel with the Typescript preset. However, presets are not currently a supported option on the cli. This pull request that adds this as an ability, which allows me to successfully use fbt-collect on a .tsx file.

## Test plan

Ran flow:check command and test command.  Both passed.
Ran fbt-collect --presets @babel/preset-typescript --pretty --manifest < .src_manifest.json > .source_strings.json on our own project with .tsx files.  Successfully generated the correct source strings.