### PR TITLE
fix: update node version used by Travis to install Prettier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - '10.19.x'
-  - '12.16.x'
+  - '10.19.*'
+  - '12.16.*'
 
 branches:
   only:
@@ -19,11 +19,11 @@ script: yarn run "$CMD"
 jobs:
   include:
     - stage: test
-      name: "Flow checks - node v10.19.x"
-      node_js: '10.19.x'
+      name: "Flow checks - node v10.19.*"
+      node_js: '10.19.*'
       script: yarn flow:check
-    - name: "Flow checks - node v12.16.x"
-      node_js: '12.16.x'
+    - name: "Flow checks - node v12.16.*"
+      node_js: '12.16.*'
       script: yarn flow:check
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - '10.4.0'
-  - '12'
+  - '10.19.x'
+  - '12.16.x'
 
 branches:
   only:
@@ -19,11 +19,11 @@ script: yarn run "$CMD"
 jobs:
   include:
     - stage: test
-      name: "Flow checks - node v10.4.0"
-      node_js: '10.4.0'
+      name: "Flow checks - node v10.19.x"
+      node_js: '10.19.x'
       script: yarn flow:check
-    - name: "Flow checks - node v12"
-      node_js: '12'
+    - name: "Flow checks - node v12.16.x"
+      node_js: '12.16.x'
       script: yarn flow:check
 
 before_install:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough
information so that others can review your pull request. The two
fields below are mandatory.
-->

<!--
Please remember to update CHANGELOG.md in the root of the project if
you have not done so.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing
problem does the pull request solve?
-->

The bug happens because we added Prettier as a new dependency but our Travis build setup is using an outdated node version.

https://travis-ci.com/github/facebook/fbt/jobs/344162645
```
$ node --version
v10.4.0
$ npm --version
6.1.0
$ nvm --version
0.35.3
$ yarn --version
1.15.2
before_install.1
2.67s$ curl -o- -L https://yarnpkg.com/install.sh | bash
before_install.2
0.00s$ export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
20.92s$ yarn --frozen-lockfile
yarn install v1.22.4
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
warning file-loader@2.0.0: Invalid bin field for "file-loader".
info fsevents@1.2.11: The platform "linux" is incompatible with this module.
info "fsevents@1.2.11" is an optional dependency and failed compatibility check. Excluding it from installation.
error prettier@2.0.5: The engine "node" is incompatible with this module. Expected version ">=10.13.0". Got "10.4.0"
error Found incompatible module.
```

Updating the node version to something compatible with it.

Fixing T68062657.

## Test plan

Let Travis run.
<!--
Demonstrate the code is solid. E.g: Commands you ran and their output,
screenshots / videos if the pull request changes UI.
-->
