### PR TITLE
Flow import * as T issue with %checks

### DIFF
--- a/flow-types/nonfb/libdef/babelTypes.js
+++ b/flow-types/nonfb/libdef/babelTypes.js
@@ -1803,6 +1803,7 @@ declare module "@babel/types" {
   declare export function tsTypeParameterInstantiation(params: Array<BabelNodeTSType>): BabelNodeTSTypeParameterInstantiation;
   declare export function tsTypeParameterDeclaration(params: Array<BabelNodeTSTypeParameter>): BabelNodeTSTypeParameterDeclaration;
   declare export function tsTypeParameter(constraint?: BabelNodeTSType, _default?: BabelNodeTSType, name: string): BabelNodeTSTypeParameter;
+  // Flow errors appear from here
   declare export function isArrayExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeArrayExpression)
   declare export function isAssignmentExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeAssignmentExpression)
   declare export function isBinaryExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeBinaryExpression)

--- a/packages/babel-plugin-fbt/index.js
+++ b/packages/babel-plugin-fbt/index.js
@@ -9,7 +9,7 @@
 'use strict';
 
 /*::
-import typeof BabelTypes from '@babel/types';
+import typeof * as BabelTypes from '@babel/types';
 import type {
   BabelTransformPlugin,
   NodePathOf,


### PR DESCRIPTION
Summary:
For some strange reason, importing babel types with the syntax `import typeof * as BabelTypes from 'babel/types'` causes Flow errors to appear.
But if we use `import typeof as BabelTypes...` instead, it works as expected.

```
$ /oss-fbt/__github__/node_modules/.bin/flow check --show-all-errors
Error -------------------------------------------------------------------- flow-types/nonfb/libdef/babelTypes.js:1806:18

boolean [1] is not supported by unclassified use SubstOnPredT.

   flow-types/nonfb/libdef/babelTypes.js:1806:18
   1806|   declare export function isArrayExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeArrayExpression)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

References:
   flow-types/nonfb/libdef/babelTypes.js:1806:94
   1806|   declare export function isArrayExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeArrayExpression)
                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]

Error -------------------------------------------------------------------- flow-types/nonfb/libdef/babelTypes.js:1807:18

boolean [1] is not supported by unclassified use SubstOnPredT.

   flow-types/nonfb/libdef/babelTypes.js:1807:18
   1807|   declare export function isAssignmentExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeAssignmentExpression)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

References:
   flow-types/nonfb/libdef/babelTypes.js:1807:99
   1807|   declare export function isAssignmentExpression(node: ?Object, opts?: ?Object): boolean %checks (node instanceof BabelNodeAssignmentExpression)
                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [1]

...

Found 238 errors
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Repro steps:

```
yarn
yarn clean-test
# run yarn flow:check or flow:watch to run Flow checks again afterwards
```

Issue related to: https://github.com/babel/babel/pull/11671

Differential Revision: D22032614

