### PR TITLE
Fix link to the current homepage

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,6 +10,6 @@ about: If you have questions, please check our Discord or StackOverflow
 
 For questions or help please see:
 
-- [The FBT help page](https://facebookincubator.github.io/fbt/help)
+- [The FBT help page](https://facebook.github.io/fbt/help)
 - [Our discord channel in Reactiflux](https://discordapp.com/invite/cQvXZr5)
 - [Our Facebook group](https://www.facebook.com/groups/498204277369868)

--- a/packages/babel-plugin-fbt-runtime/README.md
+++ b/packages/babel-plugin-fbt-runtime/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://facebookincubator.github.io/fbt/img/fbt.png" height="150" width="150" alt="FBT"/>
+  <img src="https://facebook.github.io/fbt/img/fbt.png" height="150" width="150" alt="FBT"/>
 </h1>
 
 ## FBT Babel Runtime transform
@@ -25,4 +25,4 @@
 This is the *secondary* FBT Babel transform.  Because of the way `fbt` is used internally at Facebook, by itself, the [fbt-babel-plugin](https://www.npmjs.com/package/babel-plugin-fbt-runtime) does not transpile `fbt._(...)` arguments to payloads that the [fbt runtime](https://www.npmjs.com/package/fbt) understands.  This transform takes care of that.
 
 ## Full documentation
-https://facebookincubator.github.io/fbt
+https://facebook.github.io/fbt

--- a/packages/babel-plugin-fbt/FbtUtil.js
+++ b/packages/babel-plugin-fbt/FbtUtil.js
@@ -340,7 +340,7 @@ function expandStringConcat(
   throw errorAt(
     node,
     `${moduleName} only accepts plain strings with params wrapped in ${moduleName}.param(...). ` +
-      `See the docs at https://facebookincubator.github.io/fbt/ for more info. ` +
+      `See the docs at https://facebook.github.io/fbt/ for more info. ` +
       `Expected StringLiteral, TemplateLiteral, or concatenation; ` +
       // $FlowExpectedError This BabelNode is unsupported so it may not even have a type property
       `got "${node.type}"`,

--- a/packages/babel-plugin-fbt/README.md
+++ b/packages/babel-plugin-fbt/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://facebookincubator.github.io/fbt/img/fbt.png" height="150" width="150" alt="FBT"/>
+  <img src="https://facebook.github.io/fbt/img/fbt.png" height="150" width="150" alt="FBT"/>
 </h1>
 
 
@@ -26,4 +26,4 @@
 This is the *main* FBT Babel transform.  For E2E use it should be paired with the [fbt-babel-plugin-runtime](https://www.npmjs.com/package/babel-plugin-fbt-runtime)
 
 ## Full documentation
-https://facebookincubator.github.io/fbt
+https://facebook.github.io/fbt

--- a/packages/fb-tiger-hash/README.md
+++ b/packages/fb-tiger-hash/README.md
@@ -9,7 +9,7 @@ implementation for backwards compatability.
 See [its use in HHVM](https://github.com/facebook/hhvm/blob/281303d/hphp/runtime/ext/hash/ext_hash.cpp#L94-L97)
 
 It's main intended use is for the [Facebook FBT internationalization
-framework](https://facebookincubator.github.io/fbt), where a hashing
+framework](https://facebook.github.io/fbt), where a hashing
 algorithm is supplied to create unique identifiers from source strings
 and their descriptions.
 


### PR DESCRIPTION
## Summary

The website was moved from `facebookincubator.github.io` to `facebook.github.io`, but the original link remained in several places.

## Test plan

No code was changed, just check the URL is OK.