### PR TITLE
Fix/babel plugin fbt/remove extra collect fbt files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ List of changes for each released npm package version.
 
   </details>
 
+- 0.17.1:
+  - [fix] Remove extraneous files `dist/bin/collectFBT*.js` that caused filename collisions with `dist/bin/collectFbt*.js` on case-insensitive filesystems (MacOS/Win)
 - 0.17.0:
   - [chore!] `collectFBT` renamed to `collectFbt` (BREAKING CHANGE: updates paths to binary)
   - [minor!] Add ability to write Flow annotations in JS code directly.

--- a/packages/babel-plugin-fbt/package.json
+++ b/packages/babel-plugin-fbt/package.json
@@ -4,7 +4,7 @@
   "name": "babel-plugin-fbt",
   "description": "The FBT Babel localization transform",
   "//version": "Follow SemVer specs at https://semver.org/",
-  "version": "0.17.1-beta",
+  "version": "0.17.1",
   "bin": {
     "fbt-collect": "dist/bin/collectFbt.bin.js",
     "fbt-manifest": "dist/bin/manifest.bin.js",

--- a/packages/babel-plugin-fbt/package.json
+++ b/packages/babel-plugin-fbt/package.json
@@ -4,7 +4,7 @@
   "name": "babel-plugin-fbt",
   "description": "The FBT Babel localization transform",
   "//version": "Follow SemVer specs at https://semver.org/",
-  "version": "0.17.0",
+  "version": "0.17.1-beta",
   "bin": {
     "fbt-collect": "dist/bin/collectFbt.bin.js",
     "fbt-manifest": "dist/bin/manifest.bin.js",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough
information so that others can review your pull request. The two
fields below are mandatory.
-->

<!--
Please remember to update CHANGELOG.md in the root of the project if
you have not done so.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing
problem does the pull request solve?
-->
We've received some user reports that some extraneous files that were left over after we recently renamed collectF**BT**.js to collectF**bt**.js, and collectF**BT**.bin.js to collectF**bt**.bin.js
This causes file name collisions on case-insensitive filesystems like MacOSX and Windows.

I've already amended the npm package directly so this is just a PR to officialize it.
See: https://www.npmjs.com/package/babel-plugin-fbt/v/0.17.1

## Test plan
eyeballs

<!--
Demonstrate the code is solid. E.g: Commands you ran and their output,
screenshots / videos if the pull request changes UI.
-->
