### PR TITLE
FbtTranslations: add support for modifying registered translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ List of changes for each released npm package version.
   <summary>
     Unreleased changes that have landed in master. Click to see more.
   </summary>
+
+  - [feat] Add a new `FbtTranslations.getRegisteredTranslations` function
+  - [feat] Add a new `FbtTranslations.mergeTranslations` function
 </details>
 
 - 0.16.5:

--- a/runtime/nonfb/FbtTranslations.js
+++ b/runtime/nonfb/FbtTranslations.js
@@ -14,7 +14,7 @@ import type {FbtRuntimeCallInput, FbtTranslatedInput} from 'FbtHooks';
 
 const FbtHooks = require('FbtHooks');
 
-let translatedFbts = null;
+let translatedFbts: TranslationDict = {};
 
 type TranslationStr = string;
 
@@ -30,7 +30,7 @@ const FbtTranslations = {
     const {args, options} = input;
     const hashKey = options?.hk;
     const {locale} = FbtHooks.getViewerContext();
-    const table = translatedFbts?.[locale];
+    const table = translatedFbts[locale];
     if (__DEV__) {
       if (!table && locale !== DEFAULT_SRC_LOCALE) {
         console.warn('Translations have not been provided');
@@ -48,6 +48,19 @@ const FbtTranslations = {
 
   registerTranslations(translations: TranslationDict): void {
     translatedFbts = translations;
+  },
+
+  getRegisteredTranslations(): TranslationDict {
+    return translatedFbts;
+  },
+
+  mergeTranslations(newTranslations: TranslationDict): void {
+    Object.keys(newTranslations).forEach(locale => {
+      translatedFbts[locale] = Object.assign(
+        translatedFbts[locale] ?? {},
+        newTranslations[locale],
+      );
+    });
   },
 };
 

--- a/runtime/nonfb/__tests__/FbtTranslations-test.js
+++ b/runtime/nonfb/__tests__/FbtTranslations-test.js
@@ -1,0 +1,61 @@
+// @flow
+
+import FbtTranslations from '../FbtTranslations'
+
+it('can register and get back translations', () => {
+  FbtTranslations.registerTranslations({ 'en_US': { c1: "aaa" } });
+  expect(FbtTranslations.getRegisteredTranslations()).toMatchInlineSnapshot(`
+    Object {
+      "en_US": Object {
+        "c1": "aaa",
+      },
+    }
+  `);
+})
+
+it('merges translations with the same locale as expected', () => {
+  FbtTranslations.registerTranslations({ 'en_US': { c1: "aaa" } });
+  FbtTranslations.mergeTranslations({ 'en_US': { c2: "bbb" } });
+  expect(FbtTranslations.getRegisteredTranslations()).toMatchInlineSnapshot(`
+    Object {
+      "en_US": Object {
+        "c1": "aaa",
+        "c2": "bbb",
+      },
+    }
+  `);
+})
+
+it('merges translations with different locales as expected', () => {
+  FbtTranslations.registerTranslations({ 'en_US': { c1: "aaa" } });
+  FbtTranslations.mergeTranslations({
+    'es_MX': { c1: "bbb" },
+    'cs_CZ': { c1: "ccc" },
+  });
+  expect(FbtTranslations.getRegisteredTranslations()).toMatchInlineSnapshot(`
+    Object {
+      "cs_CZ": Object {
+        "c1": "ccc",
+      },
+      "en_US": Object {
+        "c1": "aaa",
+      },
+      "es_MX": Object {
+        "c1": "bbb",
+      },
+    }
+  `);
+})
+
+it('merges translations with the same hash as expected', () => {
+  FbtTranslations.registerTranslations({ 'en_US': { c1: "aaa", c2: "bbb" } });
+  FbtTranslations.mergeTranslations({ 'en_US': { c1: "ccc" } });
+  expect(FbtTranslations.getRegisteredTranslations()).toMatchInlineSnapshot(`
+    Object {
+      "en_US": Object {
+        "c1": "ccc",
+        "c2": "bbb",
+      },
+    }
+  `);
+})


### PR DESCRIPTION
This change adds a new function `getRegisteredTranslations` into `FbtTranslations` which allows us to retrieve registered translations. For convenience, it also adds a new `mergeTranslations` function that allows us to append the translations.

Use-case: I have an application with FBT and a design system with its own FBT as well. Unfortunately, registering translations overwrites any translations previously registered so the design system (or the application) cannot register their own translations without conflicting with the other part. One solution could be to get already registered translations and re-register them modified. Another solution is to merge these two translations together.

There are many other possible solutions so I am open to suggestions how to make it better.