### PR TITLE
chore(fb-tiger-hash): bump to 0.2.0-rc1-beta

### DIFF
--- a/packages/fb-tiger-hash/package.json
+++ b/packages/fb-tiger-hash/package.json
@@ -2,7 +2,7 @@
   "name": "fb-tiger-hash",
   "description": "Native JS implementation of the Tiger hash. Optionally supports flipped byte ordering found in PHP-5.3",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.0-rc1-beta",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "license": "MIT",

--- a/packages/fb-tiger-hash/package.json
+++ b/packages/fb-tiger-hash/package.json
@@ -2,7 +2,7 @@
   "name": "fb-tiger-hash",
   "description": "Native JS implementation of the Tiger hash. Optionally supports flipped byte ordering found in PHP-5.3",
   "private": false,
-  "version": "0.1.6",
+  "version": "0.2.0",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
This commit corresponds to the beta version of the fb-tiger-hash package on npm: https://www.npmjs.com/package/fb-tiger-hash/v/0.2.0-rc1-beta