### PR TITLE
fix(babel-plugin-fbt): detect fbt JS callsites from FbtCollector [master]

### DIFF
--- a/packages/babel-plugin-fbt/src/bin/FbtCollector.js
+++ b/packages/babel-plugin-fbt/src/bin/FbtCollector.js
@@ -13,6 +13,7 @@
 
 const {extractEnumsAndFlattenPhrases} = require('../FbtShiftEnums');
 const fbt = require('../index');
+const FbtUtil = require('../FbtUtil');
 const fs = require('graceful-fs');
 
 export type ExternalTransform = (
@@ -107,7 +108,7 @@ class FbtCollector implements IFbtCollector {
       reactNativeMode: this._config.reactNativeMode,
     };
 
-    if (!/<[Ff]bt|fbt(\.c)?\s*\(/.test(source)) {
+    if (!FbtUtil.textContainsFbtLikeModule(source)) {
       return;
     }
 

--- a/packages/babel-plugin-fbt/src/bin/__tests__/__snapshots__/collectFBT-test.js.snap
+++ b/packages/babel-plugin-fbt/src/bin/__tests__/__snapshots__/collectFBT-test.js.snap
@@ -1288,6 +1288,50 @@ Object {
 }
 `;
 
+exports[`collectFbt should extract fbs strings 1`] = `
+Object {
+  "childParentMappings": Object {},
+  "phrases": Array [
+    Object {
+      "col_beg": 27,
+      "col_end": 52,
+      "jsfbt": Object {
+        "m": Array [],
+        "t": Object {
+          "desc": "foo",
+          "text": "bar",
+        },
+      },
+      "line_beg": 1,
+      "line_end": 1,
+      "project": "",
+    },
+  ],
+}
+`;
+
+exports[`collectFbt should extract fbt strings 1`] = `
+Object {
+  "childParentMappings": Object {},
+  "phrases": Array [
+    Object {
+      "col_beg": 27,
+      "col_end": 52,
+      "jsfbt": Object {
+        "m": Array [],
+        "t": Object {
+          "desc": "foo",
+          "text": "bar",
+        },
+      },
+      "line_beg": 1,
+      "line_end": 1,
+      "project": "",
+    },
+  ],
+}
+`;
+
 exports[`collectFbt should extract fbt.c strings 1`] = `
 Object {
   "childParentMappings": Object {},
@@ -1305,28 +1349,6 @@ Object {
       },
       "line_beg": 3,
       "line_end": 3,
-      "project": "",
-    },
-  ],
-}
-`;
-
-exports[`collectFbt should extract strings 1`] = `
-Object {
-  "childParentMappings": Object {},
-  "phrases": Array [
-    Object {
-      "col_beg": 27,
-      "col_end": 52,
-      "jsfbt": Object {
-        "m": Array [],
-        "t": Object {
-          "desc": "foo",
-          "text": "bar",
-        },
-      },
-      "line_beg": 1,
-      "line_end": 1,
       "project": "",
     },
   ],

--- a/packages/babel-plugin-fbt/src/bin/__tests__/collectFBT-test.js
+++ b/packages/babel-plugin-fbt/src/bin/__tests__/collectFBT-test.js
@@ -41,8 +41,13 @@ describe('collectFbt', () => {
     return JSON.parse(JSON.stringify(output));
   }
 
-  it('should extract strings', () => {
+  it('should extract fbt strings', () => {
     var res = collect('const fbt = require(\'fbt\');<fbt desc="foo">bar</fbt>');
+    expect(res).toMatchSnapshot();
+  });
+
+  it('should extract fbs strings', () => {
+    var res = collect('const fbs = require(\'fbs\');<fbs desc="foo">bar</fbs>');
     expect(res).toMatchSnapshot();
   });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough
information so that others can review your pull request. The two
fields below are mandatory.
-->

<!--
Please remember to update CHANGELOG.md in the root of the project if
you have not done so.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing
problem does the pull request solve?
-->
Running string extraction from JS files containing only `<fbs>` or `fbs()` callsites doesn't work.
This PR should fix it.

## Test plan

`yarn clean-test`

<!--
Demonstrate the code is solid. E.g: Commands you ran and their output,
screenshots / videos if the pull request changes UI.
-->
