### PR TITLE
fix(babel-plugin-fbt): detect fbt JS callsites from FbtCollector [babel-plugin-fbt/0.20.x]

### DIFF
--- a/packages/babel-plugin-fbt/src/bin/FbtCollector.js
+++ b/packages/babel-plugin-fbt/src/bin/FbtCollector.js
@@ -14,6 +14,7 @@
 const {extractEnumsAndFlattenPhrases} = require('../FbtShiftEnums');
 // eslint-disable-next-line fb-www/no-module-aliasing
 const fbt = require('../index');
+const FbtUtil = require('../FbtUtil');
 const fs = require('graceful-fs');
 const path = require('path');
 
@@ -101,7 +102,7 @@ class FbtCollector implements IFbtCollector {
       options.filename = filename;
     }
 
-    if (!/<[Ff]bt|fbt(\.c)?\s*\(/.test(source)) {
+    if (!FbtUtil.textContainsFbtLikeModule(source)) {
       return;
     }
 

--- a/packages/babel-plugin-fbt/src/bin/__tests__/collectFBT-test.js
+++ b/packages/babel-plugin-fbt/src/bin/__tests__/collectFBT-test.js
@@ -60,8 +60,23 @@ describe('collectFbt', () => {
     }
   }
 
-  it('should extract strings', () => {
+  it('should extract fbt strings', () => {
     var res = collect('const fbt = require(\'fbt\');<fbt desc="foo">bar</fbt>');
+
+    var expected = {
+      type: 'text',
+      desc: 'foo',
+      jsfbt: 'bar',
+    };
+
+    var actual = {};
+    Object.keys(expected).map(key => (actual[key] = res.phrases[0][key]));
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should extract fbs strings', () => {
+    var res = collect('const fbs = require(\'fbs\');<fbs desc="foo">bar</fbs>');
 
     var expected = {
       type: 'text',


### PR DESCRIPTION
## Summary

Running string extraction from JS files containing only <fbs> or fbs() callsites doesn't work.
This PR should fix it.

## Test plan

`yarn clean-test`