### PR TITLE
Release/babel plugin fbt/0.20.2: improve fbs detection in fbt-collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,12 +135,15 @@ List of changes for each released npm package version.
 
   </details>
 
+- 0.20.1:
+  - [fix] Fix ability to detect fbs JS callsites from FbtCollector
+
 - 0.20.0:
   - [refactor] Hang FbtUtil modules off of babel-plugin-fbt
   - [refactor]! Replace `fbtBabelPluginPath` with actual referenct to `fbtModule` in external transform
 
 - 0.19.2:
-  - [chore] Update devDependency of `gulp-strip-docblock-pragmas` 
+  - [chore] Update devDependency of `gulp-strip-docblock-pragmas`
 
 - 0.19.1:
   - [chore] Update fb-babel-plugin-utils dependency version

--- a/packages/babel-plugin-fbt/package.json
+++ b/packages/babel-plugin-fbt/package.json
@@ -4,7 +4,7 @@
   "name": "babel-plugin-fbt",
   "description": "The FBT Babel localization transform",
   "//version": "Follow SemVer specs at https://semver.org/",
-  "version": "0.20.1",
+  "version": "0.20.2-beta",
   "bin": {
     "fbt-collect": "dist/bin/collectFbt.bin.js",
     "fbt-manifest": "dist/bin/manifest.bin.js",

--- a/packages/babel-plugin-fbt/src/FbtConstants.js
+++ b/packages/babel-plugin-fbt/src/FbtConstants.js
@@ -122,9 +122,8 @@ const JSModuleName = {
 };
 
 // Used to help detect the usage of the JS fbt/fbs API inside a JS file
-const ModuleNameRegExp /*: RegExp */ = new RegExp(
-  `\\b(?:${Object.values(JSModuleName).join('|')})\\b`,
-);
+// Closely matches the Grep regexp in https://fburl.com/code/y1yt6slg
+const ModuleNameRegExp /*: RegExp */ = /<[Ff]b[st]\b|fb[st](\.c)?\s*\(/;
 
 const FBT_ENUM_MODULE_SUFFIX = '$FbtEnum';
 

--- a/packages/babel-plugin-fbt/src/__tests__/FbtConstants-test.js
+++ b/packages/babel-plugin-fbt/src/__tests__/FbtConstants-test.js
@@ -8,12 +8,45 @@
 
 'use strict';
 
-const {JSModuleName} = require('../FbtConstants');
+const {JSModuleName,ModuleNameRegExp} = require('../FbtConstants');
 
 describe('FbtConstants', () => {
   it('JSModuleName enum values should have the same string length', () => {
     for (const k in JSModuleName) {
       expect(JSModuleName[k].length).toBe(JSModuleName.FBT.length);
     }
+  });
+
+  describe('ModuleNameRegExp', () => {
+    it('should allow common fbt/fbs code patterns', () => {
+      const scenarios = [
+        `<fbt desc="..."`,
+        `fbt(foo)`,
+        `fbt.c(foo)`,
+
+        `<fbs desc="..."`,
+        `fbs(foo)`,
+        `fbs.c(foo)`,
+      ];
+
+      for (const scenario of scenarios) {
+        expect(scenario).toMatch(ModuleNameRegExp);
+      }
+    });
+
+    it('should reject code patterns resembling fbt/fbs', () => {
+      const scenarios = [
+        `<FbTask desc="..."`,
+        `fbsource(foo)`,
+        `fbt.toString()`,
+        `fbs.toString()`,
+        `const a: Fbt = ...`,
+        `const a: Fbs = ...`,
+      ];
+
+      for (const scenario of scenarios) {
+        expect(scenario).not.toMatch(ModuleNameRegExp);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

This will help reduce the number of false-positives when scanning potential JS files that need to be processed by the string extractor.

## Test plan

```
yarn clean-test
```