### PR TITLE
Fix typo in `docs/utilities.md`

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -12,9 +12,9 @@ As an example
 ```js
 const intlList = require('fbt/lib/intlList');
 const CONJUNCTIONS = intlList.CONJUNCTIONS;
-const DELIMITER = intlList.DELIMITER;
+const DELIMITERS = intlList.DELIMITERS;
 let people = ['Adam', 'Becky', fbt('4 others', 'last item')]
-intlList(people, CONJUNCTIONS.AND, DELIMITER.COMMA);
+intlList(people, CONJUNCTIONS.AND, DELIMITERS.COMMA);
 ```
 produces the fbt
 ```


### PR DESCRIPTION
See: https://github.com/facebook/fbt/blob/731f70843f61e034e1e8e2dcda15f04bd0466100/runtime/shared/intlList.js#L205-L206
