### PR TITLE
fix(babel-plugin-fbt): preserve non-breaking space characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ List of changes for each released npm package version.
       Unreleased changes that have landed in main. Click to see more.
     </summary>
 
+    - [fix]! Fixed issue where non-breaking space characters (`&nbsp;`) in `<fbt>` callsites were being replaced by space characters
     - [chore] Improve `.npmignore` config (avoid exporting some build, debug & test files)
 
     0.21.0-rc8-beta

--- a/packages/babel-plugin-fbt/src/FbtUtil.js
+++ b/packages/babel-plugin-fbt/src/FbtUtil.js
@@ -81,7 +81,9 @@ function normalizeSpaces(
   if (options && options.preserveWhitespace) {
     return value;
   }
-  return value.replace(/\s+/g, ' ');
+  // We're  willingly preserving non-breaking space characters (\u00A0)
+  // See D33402749 for more info.
+  return value.replace(/[^\S\u00A0]+/g, ' ');
 }
 
 /**

--- a/packages/babel-plugin-fbt/src/__tests__/__snapshots__/fbtJsx-test.js.snap
+++ b/packages/babel-plugin-fbt/src/__tests__/__snapshots__/fbtJsx-test.js.snap
@@ -581,6 +581,24 @@ fbt._(
 
 `;
 
+exports[`Test declarative (jsx) fbt syntax translation should support non-breasking space character 1`] = `
+const fbt = require("fbt");
+
+fbt._(
+  /* __FBT__ start */ {
+    jsfbt: {
+      t: {
+        desc: "desc with non-breaking   space",
+        text: "text with non-breaking   space",
+      },
+      m: [],
+    },
+    project: "",
+  } /* __FBT__ end */
+);
+
+`;
+
 exports[`Test declarative (jsx) fbt syntax translation should support unicode characters 1`] = `
 const fbt = require("fbt"); // A backslash \\ in comments
 

--- a/packages/babel-plugin-fbt/src/__tests__/fbtJsx-test.js
+++ b/packages/babel-plugin-fbt/src/__tests__/fbtJsx-test.js
@@ -326,6 +326,16 @@ const testData = {
     ),
   },
 
+  'should support non-breasking space character': {
+    // multiple spaces are normalized to a single space
+    // but &nbsp characters are preserved
+    input: withFbtRequireStatement(
+      `<fbt desc="desc with    non-breaking&nbsp;&nbsp;&nbsp;space">
+          text with    non-breaking&nbsp;&nbsp;&nbsp;space
+      </fbt>`,
+    ),
+  },
+
   'should support unicode characters': {
     input: withFbtRequireStatement(
       `// A backslash \\ in comments


### PR DESCRIPTION
Differential Revision: D33402749

