### PR TITLE
feat(babel-plugin-fbt): inline fbjs dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Global build-related files
 
-node_modules # @oss-only
-**/node_modules # @oss-only
+# @oss-only
+node_modules 
+# @oss-only
+**/node_modules 
 
 yarn-error.log
 .flow-results
@@ -33,7 +35,8 @@ live-demo-app/yarn-error.log
 # fbt runtime package
 packages/fbt/lib/**/*.js.flow
 packages/fbt/dist
-packages/fbt/lib # @oss-only
+# @oss-only
+packages/fbt/lib 
 packages/fbt/LICENSE
 packages/fbt/node_modules/.bin/fbt-*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ List of changes for each released npm package version.
 - [chore] Adding @noflow annotations
 - [chore] Upgrade to Flow v0.127.0
 - [fix] Relax required version patterns of npm dependencies
+- [fix] Inline `fbjs` dependency
 - Sync `babelTypeShims.js` to GitHub. It was previously missing due to internal config issues.
 - Upgrade to Flow v0.123.0
 - [doc] Add Fbt Common Strings documentation

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -74,7 +74,6 @@
     "@fbtjs/default-collection-transform": "x.x.x",
     "babel-plugin-fbt-runtime": "x.x.x",
     "babel-plugin-minify-replace": "^0.5.0",
-    "fbjs": "^1.0.0",
     "fbt": "x.x.x",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.2.0",
     "babel-plugin-minify-replace": "^0.5.0",
-    "fbjs": "^1.0.0",
     "shelljs": "^0.8.5"
   },
   "scripts": {

--- a/packages/babel-plugin-fbt/.gitignore
+++ b/packages/babel-plugin-fbt/.gitignore
@@ -1,7 +1,8 @@
 yarn.lock
 
 dist/**/*.js.flow
-dist # @oss-only
+# @oss-only
+dist 
 
 # file checksums used by gulp-once
 .checksums

--- a/packages/babel-plugin-fbt/package.json
+++ b/packages/babel-plugin-fbt/package.json
@@ -35,7 +35,6 @@
     "@babel/register": "^7.0.0",
     "@babel/types": "^7.2.2",
     "fb-babel-plugin-utils": "0.13.0-beta",
-    "fbjs": "^1.0.0",
     "flow-enums-runtime": "^0.0.4",
     "glob": "^7.1.6",
     "invariant": "^2.2.4",

--- a/packages/babel-plugin-fbt/src/FbtConstants.js
+++ b/packages/babel-plugin-fbt/src/FbtConstants.js
@@ -16,7 +16,7 @@
 
 import type {ValidPronounUsagesType} from '../../../runtime/shared/FbtRuntimeTypes';
 
-const keyMirror = require('fbjs/lib/keyMirror');
+const keyMirror = require('./utils/keyMirror');
 
 export type FbtOptionValue = string | boolean | BabelNode;
 export type FbtOptionValues<K> = {|[K]: ?FbtOptionValue|};

--- a/packages/babel-plugin-fbt/src/fbt-nodes/FbtPronounNode.js
+++ b/packages/babel-plugin-fbt/src/fbt-nodes/FbtPronounNode.js
@@ -43,7 +43,6 @@ const {
   objectExpression,
   objectProperty,
 } = require('@babel/types');
-const forEachObject = require('fbjs/lib/forEachObject');
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 
@@ -253,11 +252,13 @@ function getPronounGenderKey(
 // Prepare the list of genders actually used by the pronoun construct
 function consolidatedPronounGenders(): $ReadOnlyArray<GenderConstEnum> {
   const set = new Set();
-  forEachObject(GENDER_CONST, gender => {
-    forEachObject(ValidPronounUsagesKeys, usage => {
-      set.add(getPronounGenderKey(usage, gender));
-    });
-  });
+
+  for (const genderKey of Object.keys(GENDER_CONST)) {
+    for (const usageKey of Object.keys(ValidPronounUsagesKeys)) {
+      set.add(getPronounGenderKey(ValidPronounUsagesKeys[usageKey], GENDER_CONST[genderKey]));
+    }
+  };
+
   return Array.from(set).sort((left, right) => left - right);
 }
 

--- a/packages/babel-plugin-fbt/src/utils/keyMirror.js
+++ b/packages/babel-plugin-fbt/src/utils/keyMirror.js
@@ -1,0 +1,45 @@
+/**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ *
+ * @emails oncall+i18n_fbt_js
+ * @flow strict
+ * @format
+ */
+
+const invariant = require('invariant')
+
+/**
+ * Constructs an enumeration with keys equal to their value.
+ *
+ * For example:
+ *
+ *   const COLORS = keyMirror({blue: null, red: null});
+ *   const myColor = COLORS.blue;
+ *   const isColorValid = !!COLORS[myColor];
+ *
+ * The last line could not be performed if the values of the generated enum were
+ * not equal to their keys.
+ *
+ *   Input:  {key1: val1, key2: val2}
+ *   Output: {key1: key1, key2: key2}
+ *
+ * @param {object} obj
+ * @return {object}
+ */
+ function keyMirror<T: {}>(obj: T): $ObjMapi<T, <K>(K) => K> {
+  const ret = {};
+  let key;
+  invariant(
+    obj instanceof Object && !Array.isArray(obj),
+    "keyMirror(...): Argument must be an object."
+  );
+  for (key in obj) {
+    if (!obj.hasOwnProperty(key)) {
+      continue;
+    }
+    ret[key] = key;
+  }
+  return ret;
+};
+
+module.exports = keyMirror

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,10 +2009,6 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-
 asn1.js@^5.2.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
@@ -3449,12 +3445,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
-  dependencies:
-    iconv-lite "^0.6.2"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -3911,10 +3901,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-
 fbjs-scripts@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fbjs-scripts/-/fbjs-scripts-1.2.0.tgz#069a0c0634242d10031c6460ef1fccefcdae8b27"
@@ -3929,19 +3915,6 @@ fbjs-scripts@^1.2.0:
     plugin-error "^0.1.2"
     semver "^5.1.0"
     through2 "^2.0.0"
-
-fbjs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
-  dependencies:
-    core-js "^2.4.1"
-    fbjs-css-vars "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -4734,12 +4707,6 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
-
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -5065,7 +5032,7 @@ is-relative@^1.0.0:
   dependencies:
     is-unc-path "^1.0.0"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -5132,13 +5099,6 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6624,13 +6584,6 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
@@ -6773,7 +6726,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -7343,12 +7296,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.0.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
@@ -7903,7 +7850,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -8059,7 +8006,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
@@ -8799,10 +8746,6 @@ typescript@^3.6.4:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
 
-ua-parser-js@^0.7.18:
-  version "0.7.28"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
-
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -9310,10 +9253,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@>=0.10.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough
information so that others can review your pull request. The two
fields below are mandatory.
-->

<!--
Please remember to update CHANGELOG.md in the root of the project if
you have not done so.
-->

## Summary

Closes #321

I had to move the comments in the `.gitignore` to a separate line, otherwise the dir wouldn't be ignored for me. Not sure if there is anything on my side that is broken?

I inlined `keyMirror` but `forEachObject` I replaced with `Object.keys` and a `for of` loop

## Test plan

Existing tests pass