### PR TITLE
Update fbt peerDependencies to allow React 18.

### DIFF
--- a/packages/fbt/package.json
+++ b/packages/fbt/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "babel-plugin-fbt": "^1.0.0",
     "babel-plugin-fbt-runtime": "^1.0.0",
-    "react": "0.12.0 - 17.x.x"
+    "react": "0.12.0 - 18.x.x"
   },
   "devDependencies": {},
   "devEngines": {


### PR DESCRIPTION
## Summary

Resolves #372 by bumping the peer dependency to include React 18. This allows FBT to be properly used in projects that use React 18.

Changelog has also not been updated yet since there is no post-1.0.0 section.

## Test plan

As mentioned in #372, FBT works just fine in my own projects when running React 18. CONTRIBUTING.md doesn't have any information on how to run tests, so I didn't (but the devDependencies for different packages seem to require anywhere from React 16 to 17, which is unchanged).