### PR TITLE
Temporary fix for fbt for React 19 RC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Global build-related files
 
-node_modules # @oss-only
-**/node_modules # @oss-only
+node_modules
+**/node_modules
 
 yarn-error.log
 .flow-results
@@ -33,11 +33,11 @@ live-demo-app/yarn-error.log
 # fbt runtime package
 packages/fbt/lib/**/*.js.flow
 packages/fbt/dist
-packages/fbt/lib # @oss-only
+packages/fbt/lib
 packages/fbt/LICENSE
 packages/fbt/node_modules/.bin/fbt-*
+packages/babel-plugin-fbt/dist/
 
 # documentation build artifacts
 website/build/
-website/node_modules
 website/.docusaurus

--- a/runtime/shared/FbtReactUtil.js
+++ b/runtime/shared/FbtReactUtil.js
@@ -15,7 +15,9 @@
  */
 
 const REACT_ELEMENT_TYPE: symbol | 0xeac7 =
-  (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) ||
+  (typeof Symbol === 'function' &&
+    Symbol.for &&
+    Symbol.for('react.transitional.element')) ||
   0xeac7;
 
 let canDefineProperty = false;


### PR DESCRIPTION
## Summary

React 19 RC throws when encountering "fake" React elements. JSX likely needs to be changed significantly to work with future versions of React, but this unblocks anyone using fbt in open source. However, now fbt only works in React 19, and I'm not sure how to actually make it work both in React 18 and 19 at the same time, though.

I also had to update the `.gitignore`. One `dist` folder was missing from `.gitignore`, and it also doesn't support comments so `node_modules` weren't actually ignored.

## Test plan

I patched this into my code and it seems to work.